### PR TITLE
Fixing compilation problem with shader, adding log output if error occurs during link phase

### DIFF
--- a/elevr-player.html
+++ b/elevr-player.html
@@ -50,6 +50,9 @@
           mediump float phi = atan(direction.y, length(direction.xz));
           return texture2D(uSampler, vec2(mod(theta / (2.0*PI), 1.0), ((phi / PI + 0.5) + eye)/ 2.));
         }
+        // Should work to resolve the 'not all control paths return a value, but doesn't
+        discard;
+        return vec4(0);
       }
 
       void main(void) {

--- a/js/elevr-player.js
+++ b/js/elevr-player.js
@@ -256,7 +256,7 @@ function initShaders() {
   gl.linkProgram(shaderProgram);
 
   if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
-    alert("Unable to initialize the shader program.");
+    alert("Unable to initialize the shader program: " + gl.getProgramInfoLog(shaderProgram));
   }
 
   gl.useProgram(shaderProgram);


### PR DESCRIPTION
On my windows box, attempting to run the code without these changes results in an error that not all control paths return a value for the directionToColor() GLSL function
