### PR TITLE
create `phoneVR` only when necessary in `player-webgl.js`

### DIFF
--- a/js/elevr-player.js
+++ b/js/elevr-player.js
@@ -30,12 +30,6 @@ var timing = {showTiming: false, // Switch to true to show frame times in the co
               framesSinceIssue: 0
               };
 
-var phoneVR = null;
-
-// var ProjectionEnum = Object.freeze({
-//                   EQUIRECT: 0,
-//                   EQUIRECT_3D: 1})
-
 var container, playButton, muteButton, loopButton, fullScreenButton,
     seekBar, videoSelect, projectionSelect, canvas, video,
     leftLoad, rightLoad, leftPlay, rightPlay, playL, playR;
@@ -87,8 +81,6 @@ function runEleVRPlayer() {
     webGL.gl.disable(webGL.gl.DEPTH_TEST);
 
     util.setCanvasSize();
-
-    phoneVR = new PhoneVR();
 
     // Keyboard Controls
     controls.enableKeyControls();

--- a/js/player-webgl.js
+++ b/js/player-webgl.js
@@ -21,6 +21,15 @@ var vrHMD, vrSensor;
       }
     },
 
+    getPhoneVR: function() {
+      if (!webGL.phoneVR) {
+        // Create once and make it a property on the object for easy lookup later.
+        webGL.phoneVR = new PhoneVR();
+      }
+
+      return webGL.phoneVR;
+    },
+
     initBuffers: function() {
       positionsBuffer = webGL.gl.createBuffer();
       webGL.gl.bindBuffer(webGL.gl.ARRAY_BUFFER, positionsBuffer);
@@ -168,7 +177,7 @@ var vrHMD, vrSensor;
         }
         mat4.fromQuat(rotation, totalRotation);
       } else {
-        quat.multiply(totalRotation, manualRotation, phoneVR.rotationQuat());
+        quat.multiply(totalRotation, manualRotation, webGL.getPhoneVR().rotationQuat());
         mat4.fromQuat(rotation, totalRotation);
       }
 


### PR DESCRIPTION
small thing here I thought I'd fix. just trying to reduce the globals and move things to where they're used.
