### PR TITLE
add ability to load external video URLs (via querystring, hash, postMessage)

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,10 +130,10 @@
     <canvas id="glcanvas">
       Your browser doesn't appear to support the HTML5 <code>&lt;canvas&gt;</code> element.
     </canvas>
-    <video preload="auto" id="video" loop=true webkit-playsinline>
-      <source src="therelaxatron2.mp4" type='video/mp4'>
-        <source src="therelaxatron.webm" type='video/webm'>
-        </video>
+    <video preload="auto" id="video" loop="true" webkit-playsinline crossOrigin="anonymous">
+      <source src="therelaxatron2.mp4" type="video/mp4">
+      <source src="therelaxatron.webm" type="video/webm">
+    </video>
         <!-- Video Controls -->
         <div id="video-controls">
           <a id="play-pause" class="fa fa-play icon" title="Play"></a>

--- a/js/controls.js
+++ b/js/controls.js
@@ -82,7 +82,16 @@ var manualRotation = quat.create(),
       videoSelect.addEventListener("change", function() {
         projection = videoSelect.value[0];
         projectionSelect.value = projection;
+
+        // Remove the hash/querystring if there were custom video parameters.
+        window.history.pushState('', document.title, window.location.pathname);
+
         controls.loadVideo(videoSelect.value.substring(1));
+
+        var selectedOption = videoSelect.options[videoSelect.selectedIndex];
+        if ('autoplay' in selectedOption.dataset) {
+          controls.play();
+        }
       });
 
 
@@ -178,6 +187,13 @@ var manualRotation = quat.create(),
         controls.play();
       } else {
         controls.pause();
+      }
+    },
+
+    setLooping: function(loop) {
+      loop = !!loop;
+      if (video.loop !== loop) {
+        controls.toggleLooping();
       }
     },
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,5 @@
+/* global canvas, vrHMD, webGL */
+
 (function(global) {
   'use strict';
 
@@ -63,8 +65,6 @@
       screenHeight = window.innerHeight;
 
       if (typeof vrHMD !== 'undefined' && typeof util.isFullscreen() !== 'undefined' && util.isFullscreen()) {
-        var canvasWidth, canvasHeight;
-
         var rectHalf = vrHMD.getEyeParameters('right').renderRect;
         canvas.width = rectHalf.width * 2;
         canvas.height = rectHalf.height;
@@ -89,6 +89,126 @@
             canvas.style.height = screenHeight + 'px';
         }
       }
+    },
+
+    getExtension: function(path) {
+      return path.substr(path.lastIndexOf('.') + 1);
+    },
+
+    getBaseFilename: function(path) {
+      return path.substr(path.lastIndexOf('/') + 1);
+    },
+
+    hasVideoExtension: function(url) {
+      var ext = util.getExtension(url);
+      return ext === 'mp4' || ext === 'ogg' || ext === 'webm';
+    },
+
+    getVideoTitle: function(url) {
+      return util.hasVideoExtension(url) ? util.getBaseFilename(url) : url;
+    },
+
+    getCustomProjection: function(projection) {
+      switch (projection.toLowerCase()) {
+        case 'mono':
+        case '2d':
+        case '0':
+        case 'equirectangular':
+          return 0;
+        // Otherwise, it could be 'stereo', '3d', '1', 'equirectangular 3d', etc.
+        default:
+          return 1;
+      }
+    },
+
+    getURLSearchParams: function(qs) {
+      // Ideally, we'd use `URLSearchParams` but only Firefox supports it today.
+
+      if (typeof qs !== 'string') {
+        return {};
+      }
+
+      qs = qs.trim().replace(/^(\?|#)/, '');
+
+      if (!qs) {
+        return {};
+      }
+
+      return qs.trim().split('&').reduce(function(ret, param) {
+        var parts = param.replace(/\+/g, ' ').split('=');
+        var key = parts[0];
+        var val = parts[1];
+
+        key = decodeURIComponent(key);
+        // missing `=` should be `null`:
+        // http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
+        val = val === undefined ? null : decodeURIComponent(val);
+
+        if (!ret.hasOwnProperty(key)) {
+          ret[key] = val;
+        } else if (Array.isArray(ret[key])) {
+          ret[key].push(val);
+        } else {
+          ret[key] = [ret[key], val];
+        }
+
+        return ret;
+      }, {});
+    },
+
+    getJSONSearchParams: function(qs) {
+      if (typeof qs === 'object') {
+        return qs;
+      }
+
+      qs = decodeURIComponent(qs).trim().replace(/^(\?|#)/, '');
+
+      try {
+        return JSON.parse(qs);
+      } catch (e) {
+        return null;
+      }
+    },
+
+    getTruthyURLSearchParams: function(qs, defaults) {
+      if (!defaults) {
+        defaults = {};
+      }
+
+      var params = util.getJSONSearchParams(qs);
+
+      if (!params) {
+        params = util.getURLSearchParams(qs);
+      }
+
+      var ret = {};
+      var val;
+
+      Object.keys(defaults).forEach(function(key) {
+        ret[key] = defaults[key];
+      });
+
+      Object.keys(params).forEach(function(key) {
+        val = String(params[key]).toLowerCase();
+        switch (val) {
+          case '0':
+          case 'false':
+          case 'no':
+          case 'off':
+          case 'undefined':
+            ret[key] = false;
+            break;
+          case 'null':
+            // If it's 'null', that means it exists in the params but there's no value.
+            ret[key] = true;
+            break;
+          default:
+            ret[key] = params[key];
+            break;
+        }
+      });
+
+      return ret;
     }
   };
 


### PR DESCRIPTION
The code for handling the qs/hash/postMessage params is a bit verbose, but it handles the many possible cases well.

Let me know your thoughts. Thanks!

<hr>

## Sample usage

Query-string key-value params:
[`http://localhost:8080/?autoplay=1&video=http://cdn2.vrideo.com/prod_videos/v1/lSPg9ka_1080p_full.webm`](http://localhost:8080/?autoplay=1&video=http://cdn2.vrideo.com/prod_videos/v1/lSPg9ka_1080p_full.webm)

Hash key-value params:
[`http://localhost:8080/#video=http://cdn2.vrideo.com/prod_videos/v1/W7JUlEW_480p_full.mp4`](http://localhost:8080/#video=http://cdn2.vrideo.com/prod_videos/v1/W7JUlEW_480p_full.mp4)

Query-string JSON params:
[`http://localhost:8080/?{"video": "http://cdn2.vrideo.com/prod_videos/v1/3aM7Xd6_1080p_full.webm", "autoplay": "true", "projection": "mono"}`](http://localhost:8080/?{"video": "http://cdn2.vrideo.com/prod_videos/v1/3aM7Xd6_1080p_full.webm", "autoplay": "true", "projection": "mono"})

Hash JSON params:
[`http://localhost:8080/#{"autoplay": true, "video": "http://crossorigin.me/http://mobile.360heros.com/producers/4630608605686575/5579686187673361/video/video_7776b10db31f349ede5d253b7744e110.mp4"}`](http://localhost:8080/#{"autoplay": true, "video": "http://crossorigin.me/http://mobile.360heros.com/producers/4630608605686575/5579686187673361/video/video_7776b10db31f349ede5d253b7744e110.mp4"})

`postMessage` to the page from the JS console:
```
window.postMessage({video: 'http://cdn2.vrideo.com/prod_videos/v1/mYNVcD6_480p_full.mp4', autoplay: true, loop: true}, '*')
```

`postMessage` from an iframe:
```
data:text/html,<iframe id='i' src='http://localhost:8080' style='border: 0; position: absolute; left: 0; top: 0; height: 100%; width: 100%' allowfullscreen></iframe><script>setTimeout(function () { i.contentWindow.postMessage({video: 'http://cdn2.vrideo.com/prod_videos/v1/mYNVcD6_480p_full.mp4', autoplay: true, loop: true}, '*'); }, 300);</script>
```
