### PR TITLE
Add Recenter button

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,8 @@
 
           <a id="mute" class="fa fa-volume-up icon" title="Mute"></a>
 
+          <a id="recenter" class="fa fa-dot-circle-o icon" title="Recenter"></a>
+
           <a id="select-local-file" class="fa fa-folder-open icon rfloat" title="Select File"></a>
 
           <select id="projection-select" class="rfloat">

--- a/js/controls.js
+++ b/js/controls.js
@@ -51,6 +51,15 @@ var manualRotation = quat.create(),
         controls.fullscreen();
       });
 
+      recenterButton.addEventListener('click', function() {
+        if (typeof vrSensor !== 'undefined') {
+          vrSensor.zeroSensor(); // Untested
+        }
+        else {
+          quat.invert(manualRotation, webGL.getPhoneVR().rotationQuat());
+        }
+      });
+
       seekBar.addEventListener('change', function() {
         // Calculate the new time
         var time = video.duration * (seekBar.value / 100);
@@ -125,7 +134,12 @@ var manualRotation = quat.create(),
           controls.fullscreen();
           break;
         case 'z':
-          vrSensor.zeroSensor();
+          if (typeof vrSensor !== 'undefined') {
+            vrSensor.zeroSensor();
+          }
+          else {
+            quat.invert(manualRotation, webGL.getPhoneVR().rotationQuat());
+          }
           break;
         case 'p':
           controls.playPause();

--- a/js/elevr-player.js
+++ b/js/elevr-player.js
@@ -65,6 +65,7 @@ function setupControls() {
   window.playR = document.getElementById('play-r');
   window.muteButton = document.getElementById('mute');
   window.loopButton = document.getElementById('loop');
+  window.recenterButton = document.getElementById('recenter');
   window.fullScreenButton = document.getElementById('full-screen');
 
   // Sliders


### PR DESCRIPTION
This PR adds a "recenter" button that attempts to reset the sensor position.

If it is not possible to reset the sensor, then it sets the manual rotation to be the inverse of the current sensor data, nullifying it.

This is useful in some VR videos that, while recorded at 360º, assume that the viewer is sitting down looking into a certain direction (for example, this [cockpit video](https://www.youtube.com/watch?v=NdZ02-Qenso)).

I don't have any device were `vrSensor` is defined though. This feature was only tested on my PC and on a Nexus 5x with google cardboard.